### PR TITLE
Change "Close Forever" to "Close until Game Restart"

### DIFF
--- a/GameData/FreeIva/Localization/en-us.cfg
+++ b/GameData/FreeIva/Localization/en-us.cfg
@@ -18,7 +18,7 @@ Localization
         #FreeIVA_Tutorial_ReturnSeat = Return Seat
         #FreeIVA_Tutorial_ToggleGravity = Toggle Gravity
         #FreeIVA_Tutorial_Close = Close
-        #FreeIVA_Tutorial_CloseForever = Close Forever
+        #FreeIVA_Tutorial_CloseForever = Close until Game Restart
         #FreeIVA_Tutorial_GrabProp = Grab Prop
         #FreeIVA_Tutorial_UseProp = Use Prop
         #FreeIVA_Tutorial_PlaceProp = Place Prop


### PR DESCRIPTION
In my opinion, I think giving the correct description of what the button does will be less confusing to the player. If the button reads "Close Forever", and then it doesn't close forever, then that would lead the user to think that there was a glitch or something. Additionally, if the user thinks that the button will actually close the GUI forever, then that might scare them away from doing it in fear that they will never be able to access the tutorial again.