### PR TITLE
Fix hatch IEnumerator CheckForConnections to support PhysicsHold mod

### DIFF
--- a/FreeIva/InternalModules/Hatches/Hatch.cs
+++ b/FreeIva/InternalModules/Hatches/Hatch.cs
@@ -446,7 +446,7 @@ namespace FreeIva
 		{
 			yield return null;
 
-			while (vessel.packed)
+			while (vessel.packed && !vessel.isActiveVessel)
 			{
 				yield return null;
 			}


### PR DESCRIPTION
When PhysicsHold is installed an enabled on a base, a few bugs occur.  The most annoying one is that hatches from inside the base cease to function with FreeIVA.  This is because the vessel appears in a packed state.

Since you can only open hatches in FreeIVA mode on a packed vessel you are actually inside (and the bug does not occur from outside), simply checking if we are the active vessel before yielding null should suffice.